### PR TITLE
Re-enable aarch64 builds.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64", "aarch64"]
 }

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -28,7 +28,7 @@ modules:
       arch:
         aarch64:
           config-opts:
-            - -DENABLE_OGLRENDERER=OFF
+            - -DENABLE_LTO_RELEASE=OFF
     build-commands:
       - install -D -m644 -t /app/share/appdata/ ../${FLATPAK_ID}.appdata.xml
     sources:


### PR DESCRIPTION
OpenGL used to not work with the aarch64 KDE flatpak runtime, but this seems to no longer be the case, so let's re-enable aarch64 builds.

There's currently an issue with gcc breaking rendering on aarch64 when building with LTO, so it is disabled for now.