### PR TITLE
Update KDE runtime to 6.9, update libslirp, add x-checker-data

### DIFF
--- a/fix-build-gcc14.patch
+++ b/fix-build-gcc14.patch
@@ -1,0 +1,24 @@
+From e63e29ca91ba5fc1630634fbb9f064b9cce6cc1f Mon Sep 17 00:00:00 2001
+From: orbea <orbea@riseup.net>
+Date: Sat, 11 Nov 2023 10:31:10 -0800
+Subject: [PATCH] DSi_Camera: fix gcc-14 build issue
+
+melonDS/src/DSi_Camera.cpp:190:23: error: 'clamp' is not a member of 'std'
+  190 |             r1 = std::clamp(r1, 0, 255); g1 = std::clamp(g1, 0, 255); b1 = std::clamp(b1, 0, 255);
+      |                       ^~~~~
+---
+ src/DSi_Camera.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/DSi_Camera.cpp b/src/DSi_Camera.cpp
+index 749162932f..2b259c5902 100644
+--- a/src/DSi_Camera.cpp
++++ b/src/DSi_Camera.cpp
+@@ -16,6 +16,7 @@
+     with melonDS. If not, see http://www.gnu.org/licenses/.
+ */
+ 
++#include <algorithm>
+ #include <stdio.h>
+ #include <string.h>
+ #include "DSi.h"

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "only-arches": ["x86_64", "aarch64"]
-}

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -1,6 +1,6 @@
 app-id: net.kuribo64.melonDS
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: melonDS
 cleanup:

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -22,6 +22,9 @@ modules:
         url: https://gitlab.freedesktop.org/slirp/libslirp.git
         tag: v4.8.0
         commit: ce314e39458223c2c42245fe536fbe1bcd94e9b1
+        x-data-checker:
+          type: git
+          tag-pattern: v([\d.]+)
   - name: melonds
     buildsystem: cmake-ninja
     builddir: true
@@ -33,6 +36,10 @@ modules:
     sources:
       - type: git
         url: https://github.com/melonDS-emu/melonDS.git
+        tag: 0.9.5
         commit: 430de6b2702bb93faa8c2004aff3fbd084db4a1e
+        x-data-checker:
+          type: git
+          tag-pattern: ([\d.]+)
       - type: file
         path: net.kuribo64.melonDS.appdata.xml

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -41,5 +41,7 @@ modules:
         x-data-checker:
           type: git
           tag-pattern: ([\d.]+)
+      - type: patch
+        path: fix-build-gcc14.patch
       - type: file
         path: net.kuribo64.melonDS.appdata.xml

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -1,6 +1,6 @@
 app-id: net.kuribo64.melonDS
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: melonDS
 cleanup:

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -20,7 +20,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/slirp/libslirp.git
-        tag: v4.7.0
+        tag: v4.8.0
+        commit: ce314e39458223c2c42245fe536fbe1bcd94e9b1
   - name: melonds
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
`flathub.json` does nothing with this configuration and can be deleted.