### PR TITLE
Update melonDS to 1.0 RC

### DIFF
--- a/net.kuribo64.melonDS.appdata.xml
+++ b/net.kuribo64.melonDS.appdata.xml
@@ -13,7 +13,8 @@
   <content_rating type="oars-1.0" />
   <description>
     <p>
-      melonDS aims at providing fast and accurate Nintendo DS emulation. While it is still a work in progress, it has a pretty solid set of features.
+      melonDS aims at providing fast and accurate Nintendo DS emulation. While it is still a work in
+      progress, it has a pretty solid set of features.
     </p>
     <ul>
       <li>Nearly complete core (CPU, video, audio, ...)</li>
@@ -33,15 +34,18 @@
   <url type="donation">https://www.patreon.com/Arisotura</url>
   <screenshots>
     <screenshot type="default" environment="plasma">
-      <image width="389" height="574" scale="1">https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/1.png</image>
+      <image width="389" height="574" scale="1">
+        https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/1.png</image>
       <caption>Nintendo DS emulation.</caption>
     </screenshot>
     <screenshot environment="plasma">
-      <image width="389" height="574" scale="1">https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/2.png</image>
+      <image width="389" height="574" scale="1">
+        https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/2.png</image>
       <caption>Nintendo DSi emulation.</caption>
     </screenshot>
     <screenshot environment="plasma">
-      <image width="901" height="574" scale="1">https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/3.png</image>
+      <image width="901" height="574" scale="1">
+        https://raw.githubusercontent.com/flathub/net.kuribo64.melonDS/master/screenshots/3.png</image>
       <caption>High-resolution rendering and screen layouts.</caption>
     </screenshot>
   </screenshots>
@@ -56,6 +60,36 @@
     <control>gamepad</control>
   </supports>
   <releases>
+    <release version="1.0 RC" date="2024-11-20">
+      <description>
+        <ul>
+          <li>add splashscreen (Arisotura)</li>
+          <li>add About dialog (Nadia)</li>
+          <li>emulation fixes for calico (fincs)</li>
+          <li>make the frontend mostly thread-safe</li>
+          <li>refactor core to support multiple instances in one process</li>
+          <li>OpenGL renderer: avoid undefined Z when using W-buffering (Generic)</li>
+          <li>improve microphone input (Arisotura)</li>
+          <li>add support for multiple windows (Arisotura)</li>
+          <li>new configuration system (Arisotura)</li>
+          <li>add OpenGL compute shader renderer (Generic)</li>
+          <li>implement framerate target presets (Jakly)</li>
+          <li>fix microphone blow noise input (Generic)</li>
+          <li>add LAN support (Arisotura)</li>
+          <li>add Nix flake (Nadia)</li>
+          <li>attempts at improving local multiplayer connections (Arisotura)</li>
+          <li>many accuracy improvements to the software 3D renderer (Jakly)</li>
+          <li>fix inaccuracy with NO$GBA debug registers (pants64DS)</li>
+          <li>OpenGL renderer: add support for changing BG0HOFS midframe (Arisotura)</li>
+          <li>fix zstd ROM loading issues (Nadia)</li>
+          <li>audio: add Gaussian (SNES) interpolation (Nadia)</li>
+          <li>fix DSiWare detection (JesseTG)</li>
+          <li>add support for R4 Revolution/M3 Simply carts (asiekierka)</li>
+          <li>fix DS/GBA comm not working when using FreeBIOS (Nadia)</li>
+          <li>probably more</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.9.5" date="2022-11-03">
       <description>
         <ul>
@@ -63,8 +97,10 @@
           <li>DLDI fixes for the Smash demo (Arisotura)</li>
           <li>fix gaps in I/O handling (Arisotura)</li>
           <li>fix invalid savemem commands, fixes Dementium (Arisotura)</li>
-          <li>FreeBIOS: add VRAM-compatible LZ77 decompress function, fixes Yoshi's Island (Arisotura)</li>
-          <li>default firmware: in DSi mode, emulate DWM-W015 wifi board instead of DWM-W024 (Arisotura)</li>
+          <li>FreeBIOS: add VRAM-compatible LZ77 decompress function, fixes Yoshi's Island
+            (Arisotura)</li>
+          <li>default firmware: in DSi mode, emulate DWM-W015 wifi board instead of DWM-W024
+            (Arisotura)</li>
           <li>default firmware: save WFC settings to separate file (Arisotura)</li>
           <li>disable firmware overrides UI when firmware override isn't checked (Nadia)</li>
           <li>2D: more accurate fade/blending (Arisotura)</li>
@@ -112,7 +148,8 @@
           <li>Add support for zero addresses in AR codes 3xxxxxxx to Axxxxxxx (Arisotura)</li>
           <li>Lower window refresh rate if running too fast (RSDuck)</li>
           <li>Wifi power-saving support (RSDuck)</li>
-          <li>Allow swap-screen hotkey to swap between displaying only top screen and only bottom screen (ZackWeinstein)</li>
+          <li>Allow swap-screen hotkey to swap between displaying only top screen and only bottom
+            screen (ZackWeinstein)</li>
           <li>Add RAM search dialog (2jun0)</li>
           <li>Add power management dialog for setting battery parameters (Rayyan)</li>
         </ul>
@@ -159,7 +196,7 @@
         </ul>
       </description>
     </release>
-    <release version="0.9" date="2020-09-04"/>
+    <release version="0.9" date="2020-09-04" />
   </releases>
   <update_contact>nadia@nhp.sh</update_contact>
 </component>

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -16,11 +16,18 @@ finish-args:
   - "--filesystem=home"
 modules:
   - name: enet
-    buildsystem: cmake
     sources:
-      - type: git
-        url: https://github.com/lsalzman/enet.git
-        tag: v1.3.18
+      - sha256: 28603c895f9ed24a846478180ee72c7376b39b4bb1287b73877e5eae7d96b0dd
+        type: archive
+        url: https://github.com/lsalzman/enet/archive/v1.3.18.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 696
+          url-template: https://github.com/lsalzman/enet/archive/v$version.tar.gz
+      - type: script  # cf. https://github.com/lsalzman/enet/blob/master/README
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -ifv        
   - name: libslirp
     buildsystem: meson
     sources:

--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -1,6 +1,6 @@
 app-id: net.kuribo64.melonDS
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: melonDS
 cleanup:
@@ -15,12 +15,18 @@ finish-args:
   - "--device=all"
   - "--filesystem=home"
 modules:
+  - name: enet
+    buildsystem: cmake
+    sources:
+      - type: git
+        url: https://github.com/lsalzman/enet.git
+        tag: v1.3.18
   - name: libslirp
     buildsystem: meson
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/slirp/libslirp.git
-        tag: v4.7.0
+        tag: v4.9.0
   - name: melonds
     buildsystem: cmake-ninja
     builddir: true
@@ -32,6 +38,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/melonDS-emu/melonDS.git
-        commit: 430de6b2702bb93faa8c2004aff3fbd084db4a1e
+        commit: e3fa6f4224e0d706df3ee262ae41cfb0deadc593
       - type: file
         path: net.kuribo64.melonDS.appdata.xml


### PR DESCRIPTION
This PR updates this flatpak to use the latest [release](https://github.com/melonDS-emu/melonDS/releases/tag/1.0rc) of melonDS (Update 1.0 RC). 

The appdata manifest has been updated with the 1.0 RC release notes.

This PR also updates the KDE runtime to 6.8, `libslirp` to v4.9.0, and now bundles `enet` v1.3.18, as it is now a required dependency. 

As it stands, it should be noted that it has been over 9 months (at the time of making this), and over 4 months since the last release of melonDS. It should also be noted that this is the installation method used by the [EmuDeck](https://github.com/dragoonDorise/EmuDeck) project.