### PR TITLE
manifest: autoupdate for libenet

### DIFF
--- a/net.kuribo64.melonDS.yml
+++ b/net.kuribo64.melonDS.yml
@@ -16,15 +16,19 @@ finish-args:
   - "--filesystem=home"
 modules:
   - name: libenet
-    buildsystem: simple
     sources:
-      - type: git
-        url: https://github.com/lsalzman/enet.git
-        tag: v1.3.18
-    build-commands:
-      - autoreconf -vfi
-      - ./configure --prefix=/app
-      - make -j$(nproc --all) install
+      - sha256: 28603c895f9ed24a846478180ee72c7376b39b4bb1287b73877e5eae7d96b0dd
+        type: archive
+        url: https://github.com/lsalzman/enet/archive/v1.3.18.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 696
+          url-template: https://github.com/lsalzman/enet/archive/v$version.tar.gz
+      - type: script  # cf. https://github.com/lsalzman/enet/blob/master/README
+        dest-filename: autogen.sh
+        commands:
+          - autoreconf -ifv
+
   - name: melonds
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
Updated libenet module to use an archive source instead of git.